### PR TITLE
add ability to pass back key and value in the same longest prefix cal…

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,51 @@ namespace :radixtree do
   task :compile do
     Rake::Task[:compile_radixtree].invoke
   end
+
+  desc "run benchmarks for radixtree lib"
+  task :benchmark do
+    require "benchmark/ips"
+    require "./lib/ffi/radix_tree"
+
+    radix_tree = ::FFI::RadixTree::Tree.new
+
+    (1..1000).each do |number|
+      radix_tree.push(number.to_s, "DERP#{number}" * (number % 10))
+      radix_tree.push(number.to_s * 100, "DERP#{number}" * (number % 10))
+      radix_tree.push(number.to_s * 1000, "DERP#{number}" * (number % 10))
+    end
+
+    ::Benchmark.ips do |x|
+      x.config(:warmup => 10)
+
+      x.report("get") do
+        radix_tree.get(rand(1000).to_s * [1, 100, 100].sample)
+      end
+
+      x.report("longest prefix") do
+        radix_tree.longest_prefix(rand(1000).to_s * [1, 100, 100].sample)
+      end
+
+      x.report("get then value") do
+        val = rand(1000).to_s * [1, 100, 100].sample
+
+        radix_tree.longest_prefix(val)
+        radix_tree.longest_prefix_value(val)
+      end
+
+      x.report("prefix and value (combined)") do
+        radix_tree.longest_prefix_and_value(rand(1000).to_s * [1, 100, 100].sample)
+      end
+
+      x.report("longest prefix (miss)") do
+        radix_tree.longest_prefix("DERP DERPIE")
+      end
+
+      x.report("prefix and value (combined/miss)") do
+        radix_tree.longest_prefix_and_value("DERP DERPIE")
+      end
+    end
+  end
 end
 
 Rake::TestTask.new(:spec) do |t|

--- a/ffi-radix_tree.gemspec
+++ b/ffi-radix_tree.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "msgpack"
   spec.add_dependency "ffi"
 
+  spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "mocha"

--- a/spec/ffi/radix_tree_tree_spec.rb
+++ b/spec/ffi/radix_tree_tree_spec.rb
@@ -35,6 +35,15 @@ describe ::FFI::RadixTree::Tree do
       subject.longest_prefix("longest_prefix_").must_equal "longest_prefix_"
     end
 
+    it "#longest_prefix_and_value" do
+      subject.must_respond_to("longest_prefix_and_value")
+      subject.method(:longest_prefix_and_value).arity.must_equal 1
+      subject.longest_prefix_and_value("nothing").must_equal [nil, nil]
+      subject.push("longest_prefix_value", "test")
+      subject.push("longest_prefix_value_", "test2")
+      subject.longest_prefix_and_value("longest_prefix_value_").must_equal ["longest_prefix_value_", "test2"]
+    end
+
     it "#longest_prefix_value" do
       subject.must_respond_to("longest_prefix_value")
       subject.method(:longest_prefix_value).arity.must_equal 1

--- a/vendor/radixtree/ffi_radix_tree.cpp
+++ b/vendor/radixtree/ffi_radix_tree.cpp
@@ -44,7 +44,6 @@ const char* longest_prefix(radix_tree<std::string, std::vector<char>>* map_point
 
   if (iter != map_pointer->end()) {
     char *val  = new char[iter->first.size() + 1]{0};
-    val[iter->first.size()] = '\0';
     memcpy(val, iter->first.c_str(), iter->first.size());
 
     return val;
@@ -53,33 +52,29 @@ const char* longest_prefix(radix_tree<std::string, std::vector<char>>* map_point
   return NULL;
 }
 
-const char* longest_prefix_and_value(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, int* read_size) {
+const char* longest_prefix_and_value(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, int* read_size, int* prefix_size) {
   std::string string_key(key);
   auto iter = map_pointer->longest_match(string_key);
-  long counter = 0;
 
   if (iter != map_pointer->end()) {
-    int size_of_response = iter->second.size() + iter->first.size() + 9;
+    long counter = 0;
+    int size_of_response = iter->second.size() + iter->first.size();
     char *return_val  = new char[size_of_response]{0};
-    for( auto& val : iter->first) {
-      return_val[counter] = val;
-      counter++;
-    }
 
-    for( auto& val2 : { '[', ':', 'r', 'a', 'd', 'i', 'x', ':', ']' }) {
-      return_val[counter] = val2;
-      counter++;
-    }
+    strncpy(return_val, iter->first.c_str(), iter->first.size());
+    counter = iter->first.size();
 
     for( auto& val3 : iter->second) {
       return_val[counter] = val3;
       counter++;
     }
 
+    *prefix_size = iter->first.size();
     *read_size = size_of_response;
     return return_val;
   }
 
+  *prefix_size = 0;
   *read_size = 0;
   return NULL;
 }

--- a/vendor/radixtree/ffi_radix_tree.cpp
+++ b/vendor/radixtree/ffi_radix_tree.cpp
@@ -53,6 +53,37 @@ const char* longest_prefix(radix_tree<std::string, std::vector<char>>* map_point
   return NULL;
 }
 
+const char* longest_prefix_and_value(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, int* read_size) {
+  std::string string_key(key);
+  auto iter = map_pointer->longest_match(string_key);
+  long counter = 0;
+
+  if (iter != map_pointer->end()) {
+    int size_of_response = iter->second.size() + iter->first.size() + 9;
+    char *return_val  = new char[size_of_response]{0};
+    for( auto& val : iter->first) {
+      return_val[counter] = val;
+      counter++;
+    }
+
+    for( auto& val2 : { '[', ':', 'r', 'a', 'd', 'i', 'x', ':', ']' }) {
+      return_val[counter] = val2;
+      counter++;
+    }
+
+    for( auto& val3 : iter->second) {
+      return_val[counter] = val3;
+      counter++;
+    }
+
+    *read_size = size_of_response;
+    return return_val;
+  }
+
+  *read_size = 0;
+  return NULL;
+}
+
 const char* longest_prefix_value(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, int* read_size) {
   std::string string_key(key);
   auto iter = map_pointer->longest_match(string_key);
@@ -73,12 +104,12 @@ const char* longest_prefix_value(radix_tree<std::string, std::vector<char>>* map
   return NULL;
 }
 
-const char* fetch(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, int* read_size) {
+unsigned char* fetch(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, int* read_size) {
   auto iter = map_pointer->find(std::string(key));
   long counter = 0;
 
   if (iter != map_pointer->end()) {
-    char *return_val  = new char[iter->second.size()]{0};
+    unsigned char *return_val  = new unsigned char[iter->second.size()]{0};
     for( auto& val : iter->second ) {
       return_val[counter] = val;
       counter++;


### PR DESCRIPTION
…l; really bad way to do it, but do not want to track byte sizes across boundary

Didn't want to use the radix string/split mechanism but didn't have a lot of time to devote and allocating memory from the ruby process would be harder because we would have to track maximum byte sizes to alloc memory on the ruby side and then pass it to C; it's easier to use the pointer and read of the pointer already being returned
