### PR TITLE
Add greedy_match() and greedy_substring_match()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,44 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+```ruby
+# create a new tree
+rtree = ::FFI::RadixTree::Tree.new
+
+# add key/value pairs to the tree
+rtree.push("key1", "value1")
+rtree.push("key2", ["value2", "value3"])
+rtree.push("key3", { :attr1 => "value4", :attr2 => "value5" })
+
+# work with the collection
+if rtree.has_key?("key1")
+  val = rtree.get("key2")
+  rtree.set("key3", "value6")
+end
+
+# search the tree using the keys
+
+# keys based off the root word: "manage"
+rtree.push("manage", "base verb")
+rtree.push("managed", "past tense")
+rtree.push("manager", "noun")
+rtree.push("managers", "plural noun")
+rtree.push("managing", "present tense")
+
+# Find the key that matches the _most_ of the beggining of the search term
+rtree.longest_prefix("managerial")                # returns "manager"
+rtree.longest_prefix_and_value("managerial")      # returns ["manager", "noun"]
+rtree.longest_prefix_value("managerial")          # returns "noun"
+
+# Find all values whose keys match the _most_ of the beginning of the search term
+rtree.greedy_match("managerial")                  # returns ["noun", "plural noun"]
+
+# Find all values whose keys are included _anywhere_ in the search term
+rtree.greedy_substring_match("I managed to jump") # returns ["base verb", "past tense"]
+
+# cleanup
+rtree.destroy!
+```
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -50,6 +50,22 @@ namespace :radixtree do
       x.report("prefix and value (combined/miss)") do
         radix_tree.longest_prefix_and_value("DERP DERPIE")
       end
+
+      x.report("greedy match") do
+        radix_tree.greedy_match(rand(1000).to_s * [1, 100, 100].sample)
+      end
+
+      x.report("greedy match (miss)") do
+        radix_tree.greedy_match("DERP DERPIE")
+      end
+
+      x.report("greedy substring match") do
+        radix_tree.greedy_substring_match(rand(1000).to_s * [1, 100, 100].sample)
+      end
+
+      x.report("greedy substring match (miss)") do
+        radix_tree.greedy_substring_match("DERP DERPIE")
+      end
     end
   end
 end

--- a/lib/ffi/radix_tree.rb
+++ b/lib/ffi/radix_tree.rb
@@ -120,6 +120,21 @@ module FFI
         push_response
       end
 
+      def push_or_update(key, value)
+        response = nil
+        @first_character_present[key[0]] = true
+        storage_data = ::MessagePack.pack(value)
+        bytesize = storage_data.bytesize
+
+        ::FFI::MemoryPointer.new(:char, bytesize, true) do |memory_buffer|
+          memory_buffer.put_bytes(0, storage_data)
+          response = ::FFI::RadixTree.update(@ptr, key, memory_buffer, bytesize)
+          response ||= ::FFI::RadixTree.insert(@ptr, key, memory_buffer, bytesize)
+        end
+
+        response
+      end
+
       def get(key)
         return nil unless @first_character_present[key[0]]
         byte_pointer = get_response = nil
@@ -137,20 +152,6 @@ module FFI
         get_response
       ensure
         ::FFI::RadixTree.match_free(byte_pointer) if byte_pointer
-      end
-
-      def set(key, value)
-        push_response = nil
-        @first_character_present[key[0]] = true
-        storage_data = ::MessagePack.pack(value)
-        bytesize = storage_data.bytesize
-
-        ::FFI::MemoryPointer.new(:char, bytesize, true) do |memory_buffer|
-          memory_buffer.put_bytes(0, storage_data)
-          push_response = ::FFI::RadixTree.update(@ptr, key, memory_buffer, bytesize)
-        end
-
-        push_response
       end
 
       def longest_prefix(string)

--- a/spec/ffi/radix_tree_spec.rb
+++ b/spec/ffi/radix_tree_spec.rb
@@ -22,6 +22,10 @@ describe ::FFI::RadixTree do
       ::FFI::RadixTree.must_respond_to("insert")
     end
 
+    it "responds to #update" do
+      ::FFI::RadixTree.must_respond_to("update")
+    end
+
     it "responds to #longest_prefix" do
       ::FFI::RadixTree.must_respond_to("longest_prefix")
     end

--- a/spec/ffi/radix_tree_spec.rb
+++ b/spec/ffi/radix_tree_spec.rb
@@ -30,6 +30,14 @@ describe ::FFI::RadixTree do
       ::FFI::RadixTree.must_respond_to("longest_prefix_value")
     end
 
+    it "responds to #greedy_match" do
+      ::FFI::RadixTree.must_respond_to("greedy_match")
+    end
+
+    it "responds to #greedy_substring_match" do
+      ::FFI::RadixTree.must_respond_to("greedy_substring_match")
+    end
+
     it "responds to #match_free" do
       ::FFI::RadixTree.must_respond_to("match_free")
     end

--- a/spec/ffi/radix_tree_tree_spec.rb
+++ b/spec/ffi/radix_tree_tree_spec.rb
@@ -52,5 +52,27 @@ describe ::FFI::RadixTree::Tree do
       subject.push("longest_prefix_value_", "test2")
       subject.longest_prefix_value("longest_prefix_value_").must_equal "test2"
     end
+
+    it "#greedy_match" do
+      subject.must_respond_to("greedy_match")
+      subject.method(:greedy_match).arity.must_equal 1
+      subject.greedy_match("nothing").must_equal []
+      subject.push("greedy_match", "test")
+      subject.push("greedy_match_", "test2")
+      subject.push("no_match", "test3")
+      subject.greedy_match("greedy_match").must_equal ["test", "test2"]
+    end
+
+    it "#greedy_substring_match" do
+      subject.must_respond_to("greedy_substring_match")
+      subject.method(:greedy_substring_match).arity.must_equal 1
+      subject.greedy_substring_match("nothing").must_equal []
+      subject.push("substring", "test")
+      subject.push("substring_match", "test2")
+      subject.push("substring_no_match", "no_match")
+      subject.push("no_match", "no_match")
+      subject.push("no_match2", "no_match")
+      subject.greedy_substring_match("abc greedy_substring_match xyz").must_equal ["test", "test2"]
+    end
   end
 end

--- a/spec/ffi/radix_tree_tree_spec.rb
+++ b/spec/ffi/radix_tree_tree_spec.rb
@@ -18,21 +18,22 @@ describe ::FFI::RadixTree::Tree do
       subject.get("hello").must_equal "world"
     end
 
+    it "#push_or_update" do
+      subject.must_respond_to("push_or_update")
+      subject.method(:push_or_update).arity.must_equal 2
+      subject.push("hello", "world")
+      subject.push_or_update("hello", "updated")
+      subject.get("hello").must_equal "updated"
+      subject.push_or_update("new_key", "new_value")
+      subject.get("new_key").must_equal "new_value"
+    end
+
     it "#get" do
       subject.must_respond_to("get")
       subject.method(:get).arity.must_equal 1
       subject.get("Derp Derpy").must_be_nil
       subject.push("get", "test")
       subject.get("get").must_equal "test"
-    end
-
-    it "#set" do
-      subject.must_respond_to("set")
-      subject.method(:set).arity.must_equal 2
-      subject.push("hello", "world")
-      subject.set("hello", "updated")
-      subject.get("hello").must_equal "updated"
-      subject.set("no_match", "fail").must_equal false
     end
 
     it "#longest_prefix" do

--- a/spec/ffi/radix_tree_tree_spec.rb
+++ b/spec/ffi/radix_tree_tree_spec.rb
@@ -26,6 +26,15 @@ describe ::FFI::RadixTree::Tree do
       subject.get("get").must_equal "test"
     end
 
+    it "#set" do
+      subject.must_respond_to("set")
+      subject.method(:set).arity.must_equal 2
+      subject.push("hello", "world")
+      subject.set("hello", "updated")
+      subject.get("hello").must_equal "updated"
+      subject.set("no_match", "fail").must_equal false
+    end
+
     it "#longest_prefix" do
       subject.must_respond_to("longest_prefix")
       subject.method(:longest_prefix).arity.must_equal 1

--- a/vendor/radixtree/ffi_radix_tree.cpp
+++ b/vendor/radixtree/ffi_radix_tree.cpp
@@ -129,7 +129,7 @@ unsigned char* fetch(radix_tree<std::string, std::vector<char>>* map_pointer, co
   return NULL;
 }
 
-int greedy_match(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, const char*** matches) {
+int greedy_match(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, const char*** matches, int** match_sizes) {
   std::string string_key(key);
   typedef radix_tree<std::string, std::vector<char>>::iterator iterator;
   std::vector<iterator> vec;
@@ -137,23 +137,24 @@ int greedy_match(radix_tree<std::string, std::vector<char>>* map_pointer, const 
   long counter = 0;
 
   if (vec.size() > 0) {
-    *matches = new const char*[vec.size()]{nullptr};
+    *matches = new const char* [vec.size()]{nullptr};
+    *match_sizes = new int [vec.size()]{0};
     for (auto& iter : vec) {
-      auto ret_str = new char[iter->second.size() + 1];
+      auto ret_str = new char[iter->second.size()];
       long char_index = 0;
       for (auto& val : iter->second) {
         ret_str[char_index] = val;
         ++char_index;
       }
-      ret_str[char_index] = '\0';
       (*matches)[counter] = ret_str;
+      (*match_sizes)[counter] = iter->second.size();
       ++counter;
     }
   }
   return counter;
 }
 
-int greedy_substring_match(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, const char*** matches) {
+int greedy_substring_match(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, const char*** matches, int** match_sizes) {
   std::string string_key(key);
   typedef radix_tree<std::string, std::vector<char>>::iterator iterator;
   std::vector<iterator> vec;
@@ -161,16 +162,17 @@ int greedy_substring_match(radix_tree<std::string, std::vector<char>>* map_point
   long counter = 0;
 
   if (vec.size() > 0) {
-    *matches = new const char*[vec.size()]{nullptr};
+    *matches = new const char* [vec.size()]{nullptr};
+    *match_sizes = new int [vec.size()]{0};
     for (auto& iter : vec) {
-      auto ret_str = new char[iter->second.size() + 1];
+      auto ret_str = new char[iter->second.size()];
       long char_index = 0;
       for (auto& val : iter->second) {
         ret_str[char_index] = val;
         ++char_index;
       }
-      ret_str[char_index] = '\0';
       (*matches)[counter] = ret_str;
+      (*match_sizes)[counter] = iter->second.size();
       ++counter;
     }
   }

--- a/vendor/radixtree/ffi_radix_tree.cpp
+++ b/vendor/radixtree/ffi_radix_tree.cpp
@@ -38,6 +38,17 @@ void match_free(const char* match) {
   }
 }
 
+void multi_match_free(const char** match, int length) {
+  if (match != NULL) {
+    for (int i=0; i<length; ++i) {
+      delete[] match[i];
+      match[i] = NULL;
+    }
+    delete[] match;
+    match = NULL;
+  }
+}
+
 const char* longest_prefix(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key) {
   std::string string_key(key);
   auto iter = map_pointer->longest_match(string_key);
@@ -116,6 +127,56 @@ unsigned char* fetch(radix_tree<std::string, std::vector<char>>* map_pointer, co
 
   *read_size = 0;
   return NULL;
+}
+
+int greedy_match(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, const char*** matches) {
+  std::string string_key(key);
+  typedef radix_tree<std::string, std::vector<char>>::iterator iterator;
+  std::vector<iterator> vec;
+  map_pointer->greedy_match(string_key, vec);
+  long counter = 0;
+
+  if (vec.size() > 0) {
+    *matches = new const char*[vec.size()]{nullptr};
+    for (auto& iter : vec) {
+      auto ret_str = new char[iter->second.size() + 1];
+      long char_index = 0;
+      for (auto& val : iter->second) {
+        ret_str[char_index] = val;
+        ++char_index;
+      }
+      ret_str[char_index] = '\0';
+      (*matches)[counter] = ret_str;
+      ++counter;
+    }
+    return counter;
+  }
+  return 0;
+}
+
+int greedy_substring_match(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, const char*** matches) {
+  std::string string_key(key);
+  typedef radix_tree<std::string, std::vector<char>>::iterator iterator;
+  std::vector<iterator> vec;
+  map_pointer->greedy_substring_match(string_key, vec);
+  long counter = 0;
+
+  if (vec.size() > 0) {
+    *matches = new const char*[vec.size()]{nullptr};
+    for (auto& iter : vec) {
+      auto ret_str = new char[iter->second.size() + 1];
+      long char_index = 0;
+      for (auto& val : iter->second) {
+        ret_str[char_index] = val;
+        ++char_index;
+      }
+      ret_str[char_index] = '\0';
+      (*matches)[counter] = ret_str;
+      ++counter;
+    }
+    return counter;
+  }
+  return 0;
 }
 
 void insert(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, char* value, size_t size) {

--- a/vendor/radixtree/ffi_radix_tree.cpp
+++ b/vendor/radixtree/ffi_radix_tree.cpp
@@ -183,6 +183,10 @@ void insert(radix_tree<std::string, std::vector<char>>* map_pointer, const char*
   map_pointer->insert({std::string(key), std::vector<char>(value, value + size)});
 }
 
+bool update(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, char* value, size_t size) {
+  return map_pointer->update({std::string(key), std::vector<char>(value, value + size)});
+}
+
 void destroy(radix_tree<std::string, std::vector<char>>* map_pointer) {
   delete map_pointer;
   map_pointer = NULL;

--- a/vendor/radixtree/ffi_radix_tree.cpp
+++ b/vendor/radixtree/ffi_radix_tree.cpp
@@ -149,9 +149,8 @@ int greedy_match(radix_tree<std::string, std::vector<char>>* map_pointer, const 
       (*matches)[counter] = ret_str;
       ++counter;
     }
-    return counter;
   }
-  return 0;
+  return counter;
 }
 
 int greedy_substring_match(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, const char*** matches) {
@@ -174,9 +173,8 @@ int greedy_substring_match(radix_tree<std::string, std::vector<char>>* map_point
       (*matches)[counter] = ret_str;
       ++counter;
     }
-    return counter;
   }
-  return 0;
+  return counter;
 }
 
 void insert(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, char* value, size_t size) {

--- a/vendor/radixtree/radix_tree.hpp
+++ b/vendor/radixtree/radix_tree.hpp
@@ -71,6 +71,7 @@ public:
     void erase(iterator it);
     void prefix_match(const K &key, std::vector<iterator> &vec);
     void greedy_match(const K &key,  std::vector<iterator> &vec);
+    void greedy_substring_match(const K &key, std::vector<iterator> &vec);
     iterator longest_match(const K &key);
 
     T& operator[] (const K &lhs);
@@ -81,9 +82,11 @@ private:
 
     radix_tree_node<K, T>* begin(radix_tree_node<K, T> *node);
     radix_tree_node<K, T>* find_node(const K &key, radix_tree_node<K, T> *node, int depth);
+    std::vector<radix_tree_node<K, T>*> find_leaf_nodes_with_substr(const K &key, radix_tree_node<K, T> *node, const K &ancestor_key);
     radix_tree_node<K, T>* append(radix_tree_node<K, T> *parent, const value_type &val);
     radix_tree_node<K, T>* prepend(radix_tree_node<K, T> *node, const value_type &val);
     void greedy_match(radix_tree_node<K, T> *node, std::vector<iterator> &vec);
+    void greedy_substring_match(radix_tree_node<K, T> *node, std::vector<iterator> &vec);
 
     radix_tree(const radix_tree& other); // delete
     radix_tree& operator =(const radix_tree other); // delete
@@ -229,6 +232,23 @@ void radix_tree<K, T>::greedy_match(radix_tree_node<K, T> *node, std::vector<ite
 
     for (it = node->m_children.begin(); it != node->m_children.end(); ++it) {
         greedy_match(it->second, vec);
+    }
+}
+
+template <typename K, typename T>
+void radix_tree<K, T>::greedy_substring_match(const K &key, std::vector<iterator> &vec)
+{
+    std::vector<radix_tree_node<K, T>*> nodes;
+
+    vec.clear();
+
+    if (m_root == NULL)
+        return;
+
+    nodes = find_leaf_nodes_with_substr(key, m_root, "");
+
+    for (auto& node : nodes) {
+        vec.push_back(node);
     }
 }
 
@@ -493,6 +513,30 @@ radix_tree_node<K, T>* radix_tree<K, T>::find_node(const K &key, radix_tree_node
     }
 
     return node;
+}
+
+template <typename K, typename T>
+std::vector<radix_tree_node<K, T>*> radix_tree<K, T>::find_leaf_nodes_with_substr(const K &key, radix_tree_node<K, T> *node, const K &ancestor_key)
+{
+    std::vector<radix_tree_node<K, T>*> nodes;
+
+    if (node->m_children.empty())
+        return nodes;
+
+    typename radix_tree_node<K, T>::it_child it;
+    for (it = node->m_children.begin(); it != node->m_children.end(); ++it) {
+        if (it->second->m_is_leaf) {
+            nodes.push_back(it->second);
+        } else {
+            auto child_key = ancestor_key + it->first;
+            if (key.find(child_key) != std::string::npos ) {
+                auto found_nodes = find_leaf_nodes_with_substr(key, it->second, child_key);
+                nodes.insert(nodes.end(), found_nodes.begin(), found_nodes.end());
+            }
+        }
+    }
+
+    return nodes;
 }
 
 /*

--- a/vendor/radixtree/radix_tree.hpp
+++ b/vendor/radixtree/radix_tree.hpp
@@ -67,6 +67,7 @@ public:
     iterator end();
 
     std::pair<iterator, bool> insert(const value_type &val);
+    bool update(const value_type &val);
     bool erase(const K &key);
     void erase(iterator it);
     void prefix_match(const K &key, std::vector<iterator> &vec);
@@ -466,6 +467,22 @@ std::pair<typename radix_tree<K, T>::iterator, bool> radix_tree<K, T>::insert(co
             return std::pair<iterator, bool>(prepend(node, val), true);
         }
     }
+}
+
+template <typename K, typename T>
+bool radix_tree<K, T>::update(const value_type &val)
+{
+    if (m_root == NULL)
+        return false;
+
+    radix_tree_node<K, T> *node = find_node(val.first, m_root, 0);
+
+    // if the node is a internal node, return false
+    if (! node->m_is_leaf)
+        return false;
+
+    node->m_value = new value_type(val);
+    return true;
 }
 
 template <typename K, typename T>


### PR DESCRIPTION
`greedy_match()` already existed within the cpp code, but `greedy_substring_match()` is new.  Both return multiple results.  However, `greedy_match()` uses prefix matching, while `greedy_substring_match()` uses substring matching.