### PR TITLE
Use AutoPointer to remove need for destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ rtree.greedy_match("managerial")                  # returns ["noun", "plural nou
 
 # Find all values whose keys are included _anywhere_ in the search term
 rtree.greedy_substring_match("I managed to jump") # returns ["base verb", "past tense"]
-
-# cleanup
-rtree.destroy!
 ```
 
 ## Development

--- a/lib/ffi/radix_tree.rb
+++ b/lib/ffi/radix_tree.rb
@@ -88,18 +88,9 @@ module FFI
     attach_function :has_key, [:pointer, :string], :bool
 
     class Tree
-      def self.destroy!(tree)
-        tree.destroy! unless tree.nil?
-      end
-
       def initialize
-        @ptr = ::FFI::RadixTree.create
+        @ptr = ::FFI::AutoPointer.new(::FFI::RadixTree.create, ::FFI::RadixTree.method(:destroy))
         @first_character_present = {}
-      end
-
-      def destroy!
-        ::FFI::RadixTree.destroy(@ptr) unless @ptr.nil?
-        @ptr = nil
       end
 
       def has_key?(key)

--- a/spec/ffi/radix_tree_spec.rb
+++ b/spec/ffi/radix_tree_spec.rb
@@ -6,10 +6,6 @@ describe ::FFI::RadixTree do
       ::FFI::RadixTree.must_respond_to("create")
     end
 
-    it "responds to #destroy" do
-      ::FFI::RadixTree.must_respond_to("destroy")
-    end
-
     it "responds to #erase" do
       ::FFI::RadixTree.must_respond_to("erase")
     end


### PR DESCRIPTION
Using `::FFI::AutoPointer` removes the need for the `destroy!` method. The `@ptr` member will automatically be destroyed when the `Tree` instance is garbage-collected.