### PR TITLE
Fix memory leak with match sizes array. Fix some type mismatches.

### DIFF
--- a/lib/ffi/radix_tree.rb
+++ b/lib/ffi/radix_tree.rb
@@ -84,6 +84,7 @@ module FFI
     attach_function :greedy_match, [:pointer, :string, :pointer, :pointer], :int
     attach_function :greedy_substring_match, [:pointer, :string, :pointer, :pointer], :int
     attach_function :match_free, [:pointer], :void
+    attach_function :match_sizes_free, [:pointer], :void
     attach_function :multi_match_free, [:pointer, :int], :void
     attach_function :has_key, [:pointer, :string], :bool
 
@@ -96,6 +97,8 @@ module FFI
       def has_key?(key)
         ::FFI::RadixTree.has_key(@ptr, key)
       end
+
+      alias_method :key?, :has_key?
 
       def push(key, value)
         push_response = nil
@@ -207,8 +210,8 @@ module FFI
           ::FFI::MemoryPointer.new(:pointer) do |match_sizes_array|
             array_size = ::FFI::RadixTree.greedy_match(@ptr, string, match_array, match_sizes_array)
             if array_size > 0
-              array_sizes_pointer = match_sizes_array.read_pointer
-              match_sizes = array_sizes_pointer.get_array_of_int(0, array_size)
+              match_sizes_pointer = match_sizes_array.read_pointer
+              match_sizes = match_sizes_pointer.get_array_of_int(0, array_size)
               array_pointer = match_array.read_pointer
               char_arrays = array_pointer.get_array_of_pointer(0, array_size)
               char_arrays.each_with_index do |ptr, index|
@@ -221,7 +224,7 @@ module FFI
         get_response
       ensure
         ::FFI::RadixTree.multi_match_free(array_pointer, array_size) if array_pointer
-        ::FFI::RadixTree.match_free(match_sizes_pointer) if match_sizes_pointer
+        ::FFI::RadixTree.match_sizes_free(match_sizes_pointer) if match_sizes_pointer
       end
 
       def greedy_substring_match(string)
@@ -234,8 +237,8 @@ module FFI
           ::FFI::MemoryPointer.new(:pointer) do |match_sizes_array|
             array_size = ::FFI::RadixTree.greedy_substring_match(@ptr, string, match_array, match_sizes_array)
             if array_size > 0
-              array_sizes_pointer = match_sizes_array.read_pointer
-              match_sizes = array_sizes_pointer.get_array_of_int(0, array_size)
+              match_sizes_pointer = match_sizes_array.read_pointer
+              match_sizes = match_sizes_pointer.get_array_of_int(0, array_size)
               array_pointer = match_array.read_pointer
               char_arrays = array_pointer.get_array_of_pointer(0, array_size)
               char_arrays.each_with_index do |ptr, index|
@@ -248,7 +251,7 @@ module FFI
         get_response
       ensure
         ::FFI::RadixTree.multi_match_free(array_pointer, array_size) if array_pointer
-        ::FFI::RadixTree.match_free(match_sizes_pointer) if match_sizes_pointer
+        ::FFI::RadixTree.match_sizes_free(match_sizes_pointer) if match_sizes_pointer
       end
     end
   end

--- a/vendor/radixtree/ffi_radix_tree.cpp
+++ b/vendor/radixtree/ffi_radix_tree.cpp
@@ -32,20 +32,19 @@ bool has_key(radix_tree<std::string, std::vector<char>>* map_pointer, const char
 }
 
 void match_free(const char* match) {
-  if (match != NULL) {
-    delete[] match;
-    match = NULL;
-  }
+  delete[] match;
+}
+
+void match_sizes_free(const int* match_sizes) {
+  delete[] match_sizes;
 }
 
 void multi_match_free(const char** match, int length) {
   if (match != NULL) {
     for (int i=0; i<length; ++i) {
       delete[] match[i];
-      match[i] = NULL;
     }
     delete[] match;
-    match = NULL;
   }
 }
 
@@ -110,12 +109,12 @@ const char* longest_prefix_value(radix_tree<std::string, std::vector<char>>* map
   return NULL;
 }
 
-unsigned char* fetch(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, int* read_size) {
+char* fetch(radix_tree<std::string, std::vector<char>>* map_pointer, const char* key, int* read_size) {
   auto iter = map_pointer->find(std::string(key));
   long counter = 0;
 
   if (iter != map_pointer->end()) {
-    unsigned char *return_val  = new unsigned char[iter->second.size()]{0};
+    char *return_val  = new char[iter->second.size()]{0};
     for( auto& val : iter->second ) {
       return_val[counter] = val;
       counter++;


### PR DESCRIPTION
* The wrong variable name was being used to free the match size array allocation in `greedy_match` and `greedy_substring_match`, the result of which was that that memory was being leaked. 
* There was a type mismatch (char* vs int*) in the freeing function for the size array that may or may not cause issues, but I fixed anyway. 
* There was a type mismatch (unsigned char* / char*) in `fetch` for no apparent reason, so I fixed that too.
* Took out a few needless NULL checks and assignments in the functions that delete pointers (The C++ standard guarantees that deleting a null pointer is harmless.)
* Added the alias `key?` for `has_key?` so that RuboCop will stop bugging us about how `has_key?` is deprecated.